### PR TITLE
[mph] fix pext algorithm when BMI2 is not available

### DIFF
--- a/mph
+++ b/mph
@@ -840,19 +840,17 @@ template<class T, T size = sizeof(T) * __CHAR_BIT__>
       }
       return result;
     }();
-    return (((a & mask) * coefficient) >> nbits) & ((T(1) << mbits) - T(1));
-  } else if (__builtin_is_constant_evaluated()) {
-    T result{};
-    T m = mask;
-    auto k = 0u;
-    for (T i{}; i < size; ++i) {
-      if (m & 1) result |= ((a >> i) & 1) << k++;
-      m >>= 1;
-    }
-    return result;
-  } else {
-    __builtin_unreachable();
+    if constexpr(constexpr auto final_mask = ((T(1) << mbits) - T(1)); ((((mask) * coefficient) >> nbits) & final_mask) == final_mask)
+      return (((a & mask) * coefficient) >> nbits) & final_mask;
+  } 
+  T result{};
+  T m = mask;
+  auto k = 0u;
+  for (T i{}; i < size; ++i) {
+    if (m & 1) result |= ((a >> i) & 1) << k++;
+    m >>= 1;
   }
+  return result;
 }
 
 template<class T, u32 N = 1u>


### PR DESCRIPTION
I added a condition where, if the gaps between the mask bits are too small, the pext calculation will be done using a for loop.
The downside is that if `a`, which is the key, is a runtime variable, calculating pext will require running the for loop if the mask doesn't support the multiply trick.

As for the approach of ensuring that incorrect pext values are unique when selecting masks, I don't think it's a good solution. 
It alters the method for selecting unique values and leads to an inconsistency where, with -mbmi2, the pext function supports all masks, but without it, it only supports specific masks. 
Also, it makes mask selection more difficult and increases space usage. However, it avoids running a for loop when dealing with runtime variables.

I believe this is a decision that needs to be made by you.